### PR TITLE
Transaction Signature Refactor

### DIFF
--- a/examples/Flow.Net.Examples/AccountExamples/CreateAccountWithContractExample.cs
+++ b/examples/Flow.Net.Examples/AccountExamples/CreateAccountWithContractExample.cs
@@ -54,7 +54,7 @@ namespace Flow.Net.Examples.AccountExamples
             tx.ReferenceBlockId = latestBlock.Id;
 
             // sign and submit the transaction
-            tx = FlowTransaction.AddEnvelopeSignature(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
             
             var response = await FlowClient.SendTransactionAsync(tx);
 

--- a/examples/Flow.Net.Examples/AccountExamples/DeployUpdateDeleteContractExample.cs
+++ b/examples/Flow.Net.Examples/AccountExamples/DeployUpdateDeleteContractExample.cs
@@ -70,7 +70,7 @@ namespace Flow.Net.Examples.AccountExamples
 
             // sign and submit the transaction
             var newAccountSigner = new Sdk.Crypto.Ecdsa.Signer(newFlowAccountKey.PrivateKey, newAccountKey.HashAlgorithm, newAccountKey.SignatureAlgorithm);
-            tx = FlowTransaction.AddEnvelopeSignature(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
 
             var response = await FlowClient.SendTransactionAsync(tx);
             var sealedResponse = await FlowClient.WaitForSealAsync(response);
@@ -115,7 +115,7 @@ namespace Flow.Net.Examples.AccountExamples
 
             // sign and submit the transaction
             var newAccountSigner = new Sdk.Crypto.Ecdsa.Signer(newFlowAccountKey.PrivateKey, newAccountKey.HashAlgorithm, newAccountKey.SignatureAlgorithm);
-            tx = FlowTransaction.AddEnvelopeSignature(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
 
             var response = await FlowClient.SendTransactionAsync(tx);
             var sealedResponse = await FlowClient.WaitForSealAsync(response);
@@ -155,7 +155,7 @@ namespace Flow.Net.Examples.AccountExamples
 
             // sign and submit the transaction
             var newAccountSigner = new Sdk.Crypto.Ecdsa.Signer(newFlowAccountKey.PrivateKey, newAccountKey.HashAlgorithm, newAccountKey.SignatureAlgorithm);
-            tx = FlowTransaction.AddEnvelopeSignature(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, newAccount.Address, newAccountKey.Index, newAccountSigner);
 
             var response = await FlowClient.SendTransactionAsync(tx);
             var sealedResponse = await FlowClient.WaitForSealAsync(response);

--- a/examples/Flow.Net.Examples/EventExamples/GetEventsExample.cs
+++ b/examples/Flow.Net.Examples/EventExamples/GetEventsExample.cs
@@ -110,7 +110,7 @@ pub contract EventDemo {
             tx.ReferenceBlockId = latestBlock.Id;
 
             // sign
-            tx = FlowTransaction.AddEnvelopeSignature(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
 
             // send transaction
             var response = await FlowClient.SendTransactionAsync(tx);
@@ -162,7 +162,7 @@ transaction {{
             };
 
             // sign
-            tx = FlowTransaction.AddEnvelopeSignature(tx, flowAccount.Address, flowAccountKey.Index, flowAccountKey.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, flowAccount.Address, flowAccountKey.Index, flowAccountKey.Signer);
 
             // send transaction
             var response = await FlowClient.SendTransactionAsync(tx);

--- a/examples/Flow.Net.Examples/ExampleBase.cs
+++ b/examples/Flow.Net.Examples/ExampleBase.cs
@@ -59,7 +59,7 @@ namespace Flow.Net.Examples
                 }
             };
 
-            tx = FlowTransaction.AddEnvelopeSignature(tx, serviceAccount.Address, serviceAccountKey.Index, serviceAccountKey.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, serviceAccount.Address, serviceAccountKey.Index, serviceAccountKey.Signer);
 
             var response = await FlowClient.SendTransactionAsync(tx);
             return response.Id;
@@ -100,7 +100,7 @@ namespace Flow.Net.Examples
             tx.ReferenceBlockId = latestBlock.Id;
 
             // sign and submit the transaction
-            tx = FlowTransaction.AddEnvelopeSignature(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, creatorAccount.Address, creatorAccountKey.Index, creatorAccountKey.Signer);
 
             var response = await FlowClient.SendTransactionAsync(tx);
 

--- a/examples/Flow.Net.Examples/TransactionExamples/CreateTransactionExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/CreateTransactionExample.cs
@@ -76,7 +76,7 @@ namespace Flow.Net.Examples.TransactionExamples
             // construct a signer from your private key and configured signature/hash algorithms
             var signer = Sdk.Crypto.Ecdsa.Utilities.CreateSigner("privateKey", SignatureAlgo.ECDSA_P256, HashAlgo.SHA3_256);
 
-            FlowTransaction.AddEnvelopeSignature(tx, proposerAccount.Address, proposerKey.Index, signer);
+            FlowTransaction.AddEnvelopeSigner(tx, proposerAccount.Address, proposerKey.Index, signer);
         }
     }
 }

--- a/examples/Flow.Net.Examples/TransactionExamples/MultiPartyMultiSignatureExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/MultiPartyMultiSignatureExample.cs
@@ -53,16 +53,16 @@ namespace Flow.Net.Examples.TransactionExamples
             tx.Authorizers.Add(account1.Address);
 
             // account 1 signs the payload with key 1
-            tx = FlowTransaction.AddPayloadSignature(tx, account1.Address, account1.Keys[0].Index, account1.Keys[0].Signer);
+            tx = FlowTransaction.AddPayloadSigner(tx, account1.Address, account1.Keys[0].Index, account1.Keys[0].Signer);
 
             // account 1 signs the payload with key 2
-            tx = FlowTransaction.AddPayloadSignature(tx, account1.Address, account1.Keys[1].Index, account1.Keys[1].Signer);
+            tx = FlowTransaction.AddPayloadSigner(tx, account1.Address, account1.Keys[1].Index, account1.Keys[1].Signer);
 
             // account 2 signs the envelope with key 3
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account2.Address, account2.Keys[0].Index, account2.Keys[0].Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account2.Address, account2.Keys[0].Index, account2.Keys[0].Signer);
 
             // account 2 signs the envelope with key 3
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account2.Address, account2.Keys[1].Index, account2.Keys[1].Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account2.Address, account2.Keys[1].Index, account2.Keys[1].Signer);
 
             // send transaction
             var txResponse = await FlowClient.SendTransactionAsync(tx);

--- a/examples/Flow.Net.Examples/TransactionExamples/MultiPartySingleSignatureExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/MultiPartySingleSignatureExample.cs
@@ -54,10 +54,10 @@ namespace Flow.Net.Examples.TransactionExamples
             tx.Authorizers.Add(account1.Address);
 
             // account 1 signs the payload with key 1
-            tx = FlowTransaction.AddPayloadSignature(tx, account1.Address, account1Key.Index, account1Key.Signer);
+            tx = FlowTransaction.AddPayloadSigner(tx, account1.Address, account1Key.Index, account1Key.Signer);
 
             // account 2 signs the envelope
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account2.Address, account2Key.Index, account2Key.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account2.Address, account2Key.Index, account2Key.Signer);
 
             // send transaction
             var txResponse = await FlowClient.SendTransactionAsync(tx);

--- a/examples/Flow.Net.Examples/TransactionExamples/MultiPartyTwoAuthorizersExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/MultiPartyTwoAuthorizersExample.cs
@@ -61,10 +61,10 @@ transaction {
             tx.Authorizers.Add(account2.Address);
 
             // account 1 signs the payload with key 1
-            tx = FlowTransaction.AddPayloadSignature(tx, account1.Address, account1Key.Index, account1Key.Signer);
+            tx = FlowTransaction.AddPayloadSigner(tx, account1.Address, account1Key.Index, account1Key.Signer);
 
             // account 2 signs the envelope
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account2.Address, account2Key.Index, account2Key.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account2.Address, account2Key.Index, account2Key.Signer);
 
             // send transaction
             var txResponse = await FlowClient.SendTransactionAsync(tx);

--- a/examples/Flow.Net.Examples/TransactionExamples/SinglePartyMultiSignatureExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/SinglePartyMultiSignatureExample.cs
@@ -51,10 +51,10 @@ namespace Flow.Net.Examples.TransactionExamples
             tx.Authorizers.Add(account1.Address);
 
             // account 1 signs the envelope with key 1
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account1.Address, account1Key1.Index, account1Key1.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account1.Address, account1Key1.Index, account1Key1.Signer);
 
             // account 1 signs the envelope with key 2
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account1.Address, account1Key2.Index, account1Key2.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account1.Address, account1Key2.Index, account1Key2.Signer);
 
             // send transaction
             var txResponse = await FlowClient.SendTransactionAsync(tx);

--- a/examples/Flow.Net.Examples/TransactionExamples/SinglePartySingleSignatureExample.cs
+++ b/examples/Flow.Net.Examples/TransactionExamples/SinglePartySingleSignatureExample.cs
@@ -47,7 +47,7 @@ namespace Flow.Net.Examples.TransactionExamples
             tx.Authorizers.Add(account1.Address);
 
             // account 1 signs the envelope with key 1
-            tx = FlowTransaction.AddEnvelopeSignature(tx, account1.Address, account1Key.Index, account1Key.Signer);
+            tx = FlowTransaction.AddEnvelopeSigner(tx, account1.Address, account1Key.Index, account1Key.Signer);
 
             // send transaction
             var txResponse = await FlowClient.SendTransactionAsync(tx);

--- a/src/Flow.Net.SDK/Models/FlowSigner.cs
+++ b/src/Flow.Net.SDK/Models/FlowSigner.cs
@@ -1,0 +1,15 @@
+﻿using Flow.Net.Sdk.Crypto;
+using Google.Protobuf;
+
+namespace Flow.Net.Sdk.Models
+{
+    /// <summary>
+    /// A FlowSigner is a signer associated with a specific account key.
+    /// </summary>
+    public class FlowSigner
+    {
+        public ByteString Address { get; set; }
+        public uint KeyId { get; set; }
+        public ISigner Signer { get; set; }
+    }
+}

--- a/src/Flow.Net.SDK/Models/FlowTransaction.cs
+++ b/src/Flow.Net.SDK/Models/FlowTransaction.cs
@@ -15,6 +15,8 @@ namespace Flow.Net.Sdk.Models
         }
 
         public Dictionary<ByteString, int> SignerList { get; }
+        public IList<FlowSigner> PayloadSigners { get; set; } = new List<FlowSigner>();
+        public IList<FlowSigner> EnvelopeSigners { get; set; } = new List<FlowSigner>();
 
         /// <summary>
         /// Signs the full transaction (TransactionDomainTag + payload) with the specified account key.
@@ -24,18 +26,14 @@ namespace Flow.Net.Sdk.Models
         /// <param name="keyId"></param>
         /// <param name="signer"></param>
         /// <returns>A <see cref="FlowTransaction"/> with <see cref="FlowSignature"/> appended to <see cref="FlowTransactionBase.PayloadSignatures"/>.</returns>
-        public static FlowTransaction AddPayloadSignature(FlowTransaction flowTransaction, FlowAddress address, uint keyId, ISigner signer)
+        public static FlowTransaction AddPayloadSigner(FlowTransaction flowTransaction, FlowAddress address, uint keyId, ISigner signer)
         {
-            var canonicalPayload = Rlp.EncodedCanonicalPayload(flowTransaction);
-            var message = DomainTag.AddTransactionDomainTag(canonicalPayload);
-            var signature = signer.Sign(message);
-
-            flowTransaction.PayloadSignatures.Add(
-                new FlowSignature
+            flowTransaction.PayloadSigners.Add(
+                new FlowSigner
                 {
                     Address = address.Value,
                     KeyId = keyId,
-                    Signature = signature
+                    Signer = signer
                 });
 
             return flowTransaction;
@@ -49,18 +47,14 @@ namespace Flow.Net.Sdk.Models
         /// <param name="keyId"></param>
         /// <param name="signer"></param>
         /// <returns>A <see cref="FlowTransaction"/> with <see cref="FlowSignature"/> appended to <see cref="FlowTransactionBase.EnvelopeSignatures"/>.</returns>
-        public static FlowTransaction AddEnvelopeSignature(FlowTransaction flowTransaction, FlowAddress address, uint keyId, ISigner signer)
+        public static FlowTransaction AddEnvelopeSigner(FlowTransaction flowTransaction, FlowAddress address, uint keyId, ISigner signer)
         {
-            var canonicalAuthorizationEnvelope = Rlp.EncodedCanonicalAuthorizationEnvelope(flowTransaction);
-            var message = DomainTag.AddTransactionDomainTag(canonicalAuthorizationEnvelope);
-            var signature = signer.Sign(message);
-
-            flowTransaction.EnvelopeSignatures.Add(
-                new FlowSignature
+            flowTransaction.EnvelopeSigners.Add(
+                new FlowSigner
                 {
                     Address = address.Value,
                     KeyId = keyId,
-                    Signature = signature
+                    Signer = signer
                 });
 
             return flowTransaction;

--- a/src/Flow.Net.SDK/Models/FlowTransactionBase.cs
+++ b/src/Flow.Net.SDK/Models/FlowTransactionBase.cs
@@ -9,8 +9,6 @@ namespace Flow.Net.Sdk.Models
         protected FlowTransactionBase() : base()
         {
             Authorizers = new List<FlowAddress>();
-            PayloadSignatures = new List<FlowSignature>();
-            EnvelopeSignatures = new List<FlowSignature>();
             GasLimit = 9999;
         }
 
@@ -19,7 +17,5 @@ namespace Flow.Net.Sdk.Models
         public FlowAddress Payer { get; set; }
         public FlowProposalKey ProposalKey { get; set; }
         public IList<FlowAddress> Authorizers { get; set; }
-        public IList<FlowSignature> PayloadSignatures { get; set; }
-        public IList<FlowSignature> EnvelopeSignatures { get; set; }
     }
 }

--- a/src/Flow.Net.SDK/Models/FlowTransactionResponse.cs
+++ b/src/Flow.Net.SDK/Models/FlowTransactionResponse.cs
@@ -1,6 +1,10 @@
-﻿namespace Flow.Net.Sdk.Models
+﻿using System.Collections.Generic;
+
+namespace Flow.Net.Sdk.Models
 {
     public class FlowTransactionResponse : FlowTransactionBase
     {
+        public IList<FlowSignature> PayloadSignatures { get; set; } = new List<FlowSignature>();
+        public IList<FlowSignature> EnvelopeSignatures { get; set; } = new List<FlowSignature>();
     }
 }

--- a/src/Flow.Net.SDK/Rlp.cs
+++ b/src/Flow.Net.SDK/Rlp.cs
@@ -24,7 +24,7 @@ namespace Flow.Net.Sdk
 
         public static void AddTransactionSignatures(Protos.entities.Transaction tx, FlowTransaction flowTransaction)
         {
-            var canonicalPayload = EncodedCanonicalPayload(flowTransaction);
+            var canonicalPayload = EncodedCanonicalPayload(tx);
             var payloadSignatures = flowTransaction.PayloadSigners
                 .Select(x => x.SignatureFromSigner(canonicalPayload));
 
@@ -50,19 +50,19 @@ namespace Flow.Net.Sdk
             };
         }
 
-        private static byte[] EncodedCanonicalPayload(FlowTransaction flowTransaction)
+        private static byte[] EncodedCanonicalPayload(Protos.entities.Transaction tx)
         {
             var payloadElements = new List<byte[]>
             {
-                RLP.EncodeElement(flowTransaction.Script.ToBytesForRLPEncoding()),
-                RLP.EncodeList(flowTransaction.Arguments.Select(argument => RLP.EncodeElement(argument.Encode().ToBytesForRLPEncoding())).ToArray()),
-                RLP.EncodeElement(Utilities.Pad(flowTransaction.ReferenceBlockId.ToByteArray(), 32)),
-                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(flowTransaction.GasLimit))),
-                RLP.EncodeElement(Utilities.Pad(flowTransaction.ProposalKey.Address.Value.ToByteArray(), 8)),
-                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(flowTransaction.ProposalKey.KeyId))),
-                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(flowTransaction.ProposalKey.SequenceNumber))),
-                RLP.EncodeElement(Utilities.Pad(flowTransaction.Payer.Value.ToByteArray(), 8)),
-                RLP.EncodeList(flowTransaction.Authorizers.Select(authorizer => RLP.EncodeElement(Utilities.Pad(authorizer.Value.ToByteArray(), 8))).ToArray())
+                RLP.EncodeElement(tx.Script.FromByteStringToString().ToBytesForRLPEncoding()),
+                RLP.EncodeList(tx.Arguments.Select(argument => RLP.EncodeElement(argument.FromByteStringToString().ToBytesForRLPEncoding())).ToArray()),
+                RLP.EncodeElement(Utilities.Pad(tx.ReferenceBlockId.ToByteArray(), 32)),
+                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(tx.GasLimit))),
+                RLP.EncodeElement(Utilities.Pad(tx.ProposalKey.Address.ToByteArray(), 8)),
+                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(tx.ProposalKey.KeyId))),
+                RLP.EncodeElement(ConvertorForRLPEncodingExtensions.ToBytesFromNumber(BitConverter.GetBytes(tx.ProposalKey.SequenceNumber))),
+                RLP.EncodeElement(Utilities.Pad(tx.Payer.ToByteArray(), 8)),
+                RLP.EncodeList(tx.Authorizers.Select(authorizer => RLP.EncodeElement(Utilities.Pad(authorizer.ToByteArray(), 8))).ToArray())
             };
 
             return RLP.EncodeList(payloadElements.ToArray());


### PR DESCRIPTION
This would be a breaking change to the user-facing interface for defining transactions.

This PR moves `PayloadSignatures` and `EnvelopeSignatures` to the `TransactionResponse` and replaces those with `PayloadSigners` and `EnvelopeSigners` in the `Transaction` class. The transaction signatures are then created on submission of the transaction instead of on creation of the transaction. This was necessary in order to get the `AddressMap` replacement to work. The address replacement alters the script on transaction submission, which invalidated the payload and envelope signatures. Deferring signature calculation to after the address map replacement solves this.

This refactor (in my opinion) comes with other advantages:

1. You can now define the payload and envelope signers on `FlowTransaction` initialization, and not necessarily through the `AddPayloadSignature` method (though I left something similar in place for some continuity)
2. The application programmer does not need to remember to add payload signatures before envelope signatures - just defined in the `FlowTransaction` DTO
3. Made most of the RLP methods private so other parts of the application don't need to worry about its internals

I haven't fixed the tests yet - just wanted to show you the concept of the refactor and get some feedback of whether this is feasible to pull in. 