### PR TITLE
Replace gRPC dependency

### DIFF
--- a/src/Flow.Net.SDK/Client/FlowClientAsync.cs
+++ b/src/Flow.Net.SDK/Client/FlowClientAsync.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grpc.Net.Client;
 using static Flow.Net.Sdk.Protos.access.AccessAPI;
 using static Flow.Net.Sdk.Constants.Defaults;
 
@@ -24,24 +25,19 @@ namespace Flow.Net.Sdk.Client
         /// A gRPC client for the Flow Access API.
         /// </summary>
         /// <param name="flowNetworkUrl"></param>
-        /// <param name="channelCredentialsSecureSsl"></param>
         /// <param name="options"></param>
         /// <param name="addressMap">global address map</param>
         /// <returns><see cref="FlowClientAsync"/>.</returns>
         public FlowClientAsync(string flowNetworkUrl, 
-            bool channelCredentialsSecureSsl = false, 
-            IEnumerable<ChannelOption> options = null,
+            GrpcChannelOptions options = null,
             Dictionary<string, string> addressMap = null)
         {
+            options = options ?? new GrpcChannelOptions { Credentials = ChannelCredentials.Insecure };
+            var networkUrlWithScheme = $"dns:{flowNetworkUrl}";
+
             try
             {
-                _client = new AccessAPIClient(
-                    new Channel(
-                        flowNetworkUrl,
-                        channelCredentialsSecureSsl ? ChannelCredentials.SecureSsl : ChannelCredentials.Insecure,
-                        options
-                ));
-
+                _client = new AccessAPIClient(GrpcChannel.ForAddress(networkUrlWithScheme, options));
                 _cadenceConverter = new CadenceConverter();
                 AddressMap = addressMap ?? AddressMap;
             }

--- a/src/Flow.Net.SDK/Flow.Net.Sdk.csproj
+++ b/src/Flow.Net.SDK/Flow.Net.Sdk.csproj
@@ -21,8 +21,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Google.Protobuf" Version="3.20.0" />
-		<PackageReference Include="Grpc" Version="2.45.0" />
-		<PackageReference Include="Grpc.Core" Version="2.45.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.46.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.45.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Replaces legacy `Grpc.Core` package with `Grpc.Net.Client`.

In my testing with `access.devnet.nodes.onflow.org:9000 ` I could only get the client to work in insecure mode. 
SSL connections seem to fail every time. Am I missing something or are all the onflow connections unencrypted?

Fixes #74 