### PR TITLE
fix: js-testing style cdc file can't resolve in address map

### DIFF
--- a/src/Flow.Net.Sdk.Core/Models/FlowInteractionBase.cs
+++ b/src/Flow.Net.Sdk.Core/Models/FlowInteractionBase.cs
@@ -23,7 +23,7 @@ namespace Flow.Net.Sdk.Core.Models
 
         private static string ReplaceImports(string txText, Dictionary<string, string> addressMap)
         {
-            const string pattern = @"^(\s*import\s+\w+\s+from\s+)(?:0x)?(\w+)\s*$";
+            const string pattern = @"^(\s*import\s+\w+\s+from\s+)(?:0x)?(.+)\s*$";
             return string.Join("\n",
                 txText.Split('\n')
                 .Select(line =>
@@ -31,7 +31,7 @@ namespace Flow.Net.Sdk.Core.Models
                     var match = Regex.Match(line, pattern);
                     if (match.Success && match.Groups.Count == 3)
                     {
-                        var key = match.Groups[2].Value;
+                        var key = match.Groups[2].Value.replace("\"","");
                         var replAddress = addressMap.GetValueOrDefault(key)
                             ?? addressMap.GetValueOrDefault($"0x{key}");
                         if (!string.IsNullOrEmpty(replAddress))


### PR DESCRIPTION
Some cadence developers use [flow-js-testing](https://github.com/onflow/flow-js-testing) write contract, the import path is relative system path, like `import FungibleToken from "../../contracts/FungibleToken.cdc"`. Should change the regex to match this style codes.