### PR TITLE
fix: relative import style cdc file can't resolve in addressMap

### DIFF
--- a/src/Flow.Net.Sdk.Core/Models/FlowInteractionBase.cs
+++ b/src/Flow.Net.Sdk.Core/Models/FlowInteractionBase.cs
@@ -1,5 +1,6 @@
 ﻿using Flow.Net.Sdk.Core.Cadence;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -23,7 +24,7 @@ namespace Flow.Net.Sdk.Core.Models
 
         private static string ReplaceImports(string txText, Dictionary<string, string> addressMap)
         {
-            const string pattern = @"^(\s*import\s+\w+\s+from\s+)(?:0x)?(\w+)\s*$";
+            const string pattern = @"^(\s*import\s+\w+\s+from\s+)(?:0x)?(.+)\s*$";
             return string.Join("\n",
                 txText.Split('\n')
                 .Select(line =>
@@ -33,7 +34,9 @@ namespace Flow.Net.Sdk.Core.Models
                     {
                         var key = match.Groups[2].Value;
                         var replAddress = addressMap.GetValueOrDefault(key)
-                            ?? addressMap.GetValueOrDefault($"0x{key}");
+                            ?? addressMap.GetValueOrDefault($"0x{key}")
+                            ?? addressMap.GetValueOrDefault(Path.GetFileNameWithoutExtension(key))
+                            ?? addressMap.GetValueOrDefault(key.Replace("\"", ""));
                         if (!string.IsNullOrEmpty(replAddress))
                         {
                             replAddress = replAddress.TrimStart("0x");

--- a/tests/Flow.Net.SDK.Tests/ConverterTest.cs
+++ b/tests/Flow.Net.SDK.Tests/ConverterTest.cs
@@ -210,6 +210,53 @@ namespace Flow.Net.Sdk.Tests
 
             Assert.Equal(NormalizeNewLines(expected), NormalizeNewLines(tx.Script));
         }
+        
+        [Fact]
+        public void ReplaceImportsFromAddressMapRelativePath()
+        {
+            var expected = @"
+            import FungibleToken from 0x1111
+            import FUSD from 0x2222
+            
+            transaction(arg1: String) {
+                prepare(acct: AuthAccount) {
+                    log(""Hello World"")
+                }
+            }
+            ";
+            var script = @"
+            import FungibleToken from ""./contract/FungibleToken.cdc""
+            import FUSD from ""./FUSD.cdc""
+            
+            transaction(arg1: String) {
+                prepare(acct: AuthAccount) {
+                    log(""Hello World"")
+                }
+            }
+            ";
+            var address = new FlowAddress("0x123456");
+            var addressMap = new Dictionary<string, string>()
+            {
+                { "./contract/FungibleToken.cdc", "0x1111" },
+                { "FUSD", "0x2222" }
+            };
+            var tx = new FlowTransaction(addressMap)
+            {
+                Script = script,
+                Payer = address,
+                GasLimit = 100,
+                ReferenceBlockId = "",
+                ProposalKey = new FlowProposalKey()
+                {
+                    Address = address
+                }
+            };
+
+            var result = tx.FromFlowTransaction();
+
+            Assert.Equal(NormalizeNewLines(expected), NormalizeNewLines(result.Script.ByteStringToString()));
+        }
+        
         private static string NormalizeNewLines(string value)
         {
             return value


### PR DESCRIPTION
Add two style address map keys to resolve js-testing style cadence code, such as `import FungibleToken from "./contract/FungibleToken.cdc"`. 
I add a unit test, and the ?? operator should not break existing codes.